### PR TITLE
Josm link

### DIFF
--- a/osmchadjango/changeset/models.py
+++ b/osmchadjango/changeset/models.py
@@ -46,7 +46,7 @@ class Changeset(models.Model):
         """Return the link to the changeset page on ACHAVI."""
         return 'https://overpass-api.de/achavi/?changeset=%s' % self.id
 
-    def josm_url(self):
+    def josm_link(self):
         """Return link to open changeset in JOSM."""
         josm_base = "http://127.0.0.1:8111/import?url="
         changeset_url = "http://www.openstreetmap.org/api/0.6/changeset/%s/download" % self.id

--- a/osmchadjango/changeset/models.py
+++ b/osmchadjango/changeset/models.py
@@ -46,6 +46,12 @@ class Changeset(models.Model):
         """Return the link to the changeset page on ACHAVI."""
         return 'https://overpass-api.de/achavi/?changeset=%s' % self.id
 
+    def josm_url(self):
+        """Return link to open changeset in JOSM."""
+        josm_base = "http://127.0.0.1:8111/import?url="
+        changeset_url = "http://www.openstreetmap.org/api/0.6/changeset/%s/download" % self.id
+        return "%s%s" % (josm_base, changeset_url,)
+
 
 class Import(models.Model):
     """Class to register the import of Changesets."""

--- a/osmchadjango/changeset/templates/changeset/changeset_detail.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_detail.html
@@ -52,6 +52,14 @@
                 <a href="{{ changeset.osm_link }}">{{ changeset.osm_link }}</a>
               </p>
           </div>
+          <div class="list-group-item">
+              <h4 class="list-group-item-heading">{% trans 'Open in JOSM' %}</h4>
+              <p class="list-group-item-text">
+                <a class="openInJOSM" target="_blank" href="{{ changeset.josm_url }}">
+                  {% trans 'Click here to open changeset in JOSM' %}
+                </a>
+              </p>
+          </div>
       </div>
     </div>
     <div class="col-xs-12 col-md-6">

--- a/osmchadjango/changeset/templates/changeset/changeset_detail.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_detail.html
@@ -55,7 +55,7 @@
           <div class="list-group-item">
               <h4 class="list-group-item-heading">{% trans 'Open in JOSM' %}</h4>
               <p class="list-group-item-text">
-                <a class="openInJOSM" target="_blank" href="{{ changeset.josm_url }}">
+                <a class="openInJOSM" target="_blank" href="{{ changeset.josm_link }}">
                   {% trans 'Click here to open changeset in JOSM' %}
                 </a>
               </p>

--- a/osmchadjango/changeset/tests/test_models.py
+++ b/osmchadjango/changeset/tests/test_models.py
@@ -45,6 +45,12 @@ class TestChangesetModel(TestCase):
             self.changeset.osm_link(),
             'http://www.openstreetmap.org/changeset/31982803'
             )
+        self.assertEqual(
+            self.changeset.josm_link(),
+            ('http://127.0.0.1:8111/import?url='
+             'http://www.openstreetmap.org/api/0.6/changeset/31982803/download'
+             )
+            )
         self.assertEqual(SuspicionReasons.objects.all().count(), 2)
 
 

--- a/osmchadjango/static/js/project.js
+++ b/osmchadjango/static/js/project.js
@@ -1,1 +1,19 @@
 /* Project specific Javascript goes here. */
+
+(function($) {
+
+    $(function() {
+        $('.openInJOSM').click(function(e) {
+            e.preventDefault();
+            var link = $(this).attr('href');
+            $.get(link)
+                .done(function(response) {
+                    //opened successfully, don't do anything
+                })
+                .fail(function(err) {
+                    alert("Failed to open in JOSM. Is JOSM running?");
+                });
+        });
+    });
+
+})(jQuery);


### PR DESCRIPTION
Refs #11

Some doubts about the implementation:

 - The front-end right now seems a little repetitive (says Open in JOSM and then "Click here to open in JOSM..." - can we simplify this while remaining consistent with rest of the interface?)
 - I have put the javascript in `project.js` which is common across all pages. Should we create a separate JS file just for the changeset detail page?

Would love any other feedback. Thank you.