### PR TITLE
add block.super to javascript block to get jquery and bootstrap js

### DIFF
--- a/osmchadjango/changeset/templates/changeset/changeset_detail.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_detail.html
@@ -118,5 +118,6 @@
 {% endblock content %}
 
 {% block javascript %}
+  {{ block.super }}
 <script src="{% static 'js/josm_link.js' %}"></script>
 {% endblock javascript %}


### PR DESCRIPTION
Minor fix: jQuery and Bootstrap JS were no longer being loaded on changeset_detail page because it was over-riding `{% block javascript %}` -- just added a `{{ block.super }}` to keep the js from the base template.

Fixes JS not triggering when clicking on Open in JOSM button.