### PR TITLE
link user name to OSM user page, fixes #16

### DIFF
--- a/osmchadjango/changeset/templates/changeset/changeset_detail.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_detail.html
@@ -42,7 +42,11 @@
         </div>
         <div class="list-group-item">
           <h4 class="list-group-item-heading">{% trans 'User' %}</h4>
-          <p class="list-group-item-text">{{ changeset.user }}</p>
+          <p class="list-group-item-text">
+            <a href="https://www.openstreetmap.org/user/{{ changeset.user }}" target="_blank">
+              {{ changeset.user }}
+            </a>
+          </p>
         </div>
         <div class="list-group-item">
           <h4 class="list-group-item-heading">{% trans 'Editor' %}</h4>


### PR DESCRIPTION
References issue #16, adds a link from the user name on the changeset detail page to the user detail page on OSM.

@willemarcel let me know if this is not such a good idea or if you would rather implement it some other way. Thank you so much!