### PR TITLE
harmful-changeset-toggle

### DIFF
--- a/osmchadjango/changeset/templates/changeset/changeset_list.html
+++ b/osmchadjango/changeset/templates/changeset/changeset_list.html
@@ -145,7 +145,7 @@
             Only harmful
           </label>
           <label class="radio-inline">
-            <input name="harmful" type="radio" value="None" {% if get.harmful == None %} checked {% endif %} />
+            <input name="harmful" type="radio" value="All" {% if get.harmful == 'All' %} checked {% endif %} />
             All
           </label>
         </div>

--- a/osmchadjango/changeset/views.py
+++ b/osmchadjango/changeset/views.py
@@ -116,7 +116,7 @@ class ChangesetListView(ListView):
         if 'is_whitelisted' not in params:
             params['is_whitelisted'] = 'True'
         if 'harmful' not in params:
-            params['harmful'] = None
+            params['harmful'] = "All"
         if 'checked' not in params:
             params['checked'] = 'All'
         queryset = ChangesetFilter(params, queryset=queryset).qs


### PR DESCRIPTION
Harmful toggle in changeset list filters is selected `All` by default in this PR. Fixes https://github.com/willemarcel/osmcha-django/issues/73.

cc @willemarcel 