### PR TITLE
allow setting OSMCHA_FRONTEND_VERSION as env var

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -113,7 +113,10 @@ FIXTURE_DIRS = (
 # ------------------------------------------------------------------------------
 EMAIL_BACKEND = env('DJANGO_EMAIL_BACKEND', default='django.core.mail.backends.smtp.EmailBackend')
 
-FRONTEND_JS_URL = env('FRONTEND_JS_URL', default='foobar.js')
+# FRONTEND SETTINGS
+# -----------------------------------------------------------------------------
+# Version or any valid git branch tag of front-end code
+OSMCHA_FRONTEND_VERSION = env('OSMCHA_FRONTEND_VERSION', default='oh-pages')
 
 # MANAGER CONFIGURATION
 # ------------------------------------------------------------------------------

--- a/osmchadjango/frontend/management/commands/update_frontend.py
+++ b/osmchadjango/frontend/management/commands/update_frontend.py
@@ -23,7 +23,7 @@ class Command(BaseCommand):
         repo = git.Repo.clone_from(
             'https://github.com/mapbox/osmcha-frontend.git',
             temp_dir,
-            branch='oh-pages'
+            branch=settings.OSMCHA_FRONTEND_VERSION
             )
         print('Cloned osmcha-frontend ({}) to {}'.format(repo.commit().hexsha, temp_dir))
 


### PR DESCRIPTION
cc @willemarcel allows a specific commit hash or tag for the frontend code to be specified as an env var