### PR TITLE
disable cachalot in aws-production settings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,0 +1,44 @@
+Change Log
+==========
+
+Log of changes since the version 2.0
+
+[2.3.1] - 2017-07-28
+
+- Disable 'cachealot' in aws-production settings
+- Update osmcha lib version to 0.4.0
+- Add CHANGELOG.rst
+
+[2.3.0] - 2017-07-25
+
+- Add 'uid' field to BlacklistedUser model
+- use 'uid' instead of 'id' in BlacklistUser views
+- Allow put and patch method on BlacklistedUserDetailAPIView
+- Add filter by 'uid' in list changeset and feature endpoints
+
+[2.2.1] - 2017-07-18
+
+- Improve 'date' and 'check_date' filters to avoid XSS
+- Update documentation of AOIListCreateAPIView
+
+
+[2.2.0] - 2017-07-15
+
+- Add date field to AreaOfInterest and ordering to its list endpoint
+
+
+[2.1.1] - 2017-07-14
+
+- Add number of changesets in the stats views
+- Update osmcha version to 0.3.9 in requirements
+
+
+[2.1.0] - 2017-07-12
+
+- Fix changeset and feature filters inside AoI
+- Adjust django swagger authentication settings
+
+
+[2.0] - 2017-06-21
+
+- A general rewrite of osmcha-django to serve data in a REST API.

--- a/config/settings/aws_production.py
+++ b/config/settings/aws_production.py
@@ -83,3 +83,6 @@ REST_FRAMEWORK = {
         },
     'ORDERING_PARAM': 'order_by',
     }
+
+# CACHALOT SETTINGS
+CACHALOT_ENABLED = False

--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -355,6 +355,10 @@ SWAGGER_SETTINGS = {
         },
     }
 
+# CACHALOT SETTINGS
+CACHALOT_TIMEOUT = 180
+CACHALOT_ENABLED = True
+
 # FRONTEND SETTINGS
 # -----------------------------------------------------------------------------
 # Version or any valid git branch tag of front-end code

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -54,7 +54,7 @@ django-cachalot==1.5.0
 # Your custom requirements go here
 PyYAML==3.12
 # using the premerge version of osmcha
-osmcha==0.3.9
+osmcha==0.4.0
 
 # git python is required by the frontend management command
 GitPython==2.1.5


### PR DESCRIPTION
As we don't have a cache backend configured in the servers, cachalot was causing inconsistent results in the `AOI` endpoint. It is disabled in the AWS production settings until we configure the cache solution.