### PR TITLE
Add aoi-param to atom-link

### DIFF
--- a/osmchadjango/supervise/tests/test_views.py
+++ b/osmchadjango/supervise/tests/test_views.py
@@ -754,6 +754,11 @@ class TestAoIChangesetListView(APITestCase):
         rss_data = ET.fromstring(response.content).getchildren()[0].getchildren()
         title = [i for i in rss_data if i.tag == 'title'][0]
         items = [i for i in rss_data if i.tag == 'item']
+        link = [i for i in rss_data if i.tag == 'link']
+        self.assertIn(
+            "?aoi=",
+            link.text
+            )
         self.assertEqual(
             title.text,
             'Changesets of Area of Interest {} by {}'.format(

--- a/osmchadjango/supervise/views.py
+++ b/osmchadjango/supervise/views.py
@@ -138,7 +138,7 @@ class AOIListChangesetsFeedView(Feed):
         return item.bbox
 
     def item_link(self, item):
-        return reverse('frontend:changeset-detail', args=[item.id])
+        return reverse('frontend:changeset-detail', args=[item.id], kwargs={'aoi':obj.id})
 
     def item_pubdate(self, item):
         return item.date


### PR DESCRIPTION
The link-element now shows https://osmcha.mapbox.com/changesets/<id>/?aoi=<hash> which will tell the left sidebar to load the aoi-search that was used to generate the atom-feed. This way the user can continue looking at changesets from this aoi-search via the sidebar.

Co-Authored-By: @willemarcel – this is what we edited today at #SOTM Heidelberg. Since we could not run the specs, ideally you can take over from here.

Thanks for the help!

I am not absolutely sure how the two link the _guid_ and the _link_ will behave. Maybe this change will change both, or just the link. And in the later case, there might be rss-readers that only respect one of those. But the easiest to verify this is probably to just get is live and see …