### PR TITLE
Miscellaneous changes to make OSMCha run on K8s

### DIFF
--- a/compose/django/entrypoint.sh
+++ b/compose/django/entrypoint.sh
@@ -12,7 +12,11 @@ if [ -z "$POSTGRES_USER" ]; then
     export POSTGRES_USER=postgres
 fi
 
-export PGHOST=postgres
+if [ -z "$POSTGRES_HOST" ]; then
+    export POSTGRES_HOST=postgres
+fi
+
+export PGHOST=$POSTGRES_HOST
 export POSTGRES_USER=$POSTGRES_USER
 export POSTGRES_PASSWORD=$POSTGRES_PASSWORD
 # export DATABASE_URL=postgres://$POSTGRES_USER:$POSTGRES_PASSWORD@postgres:5432/$POSTGRES_USER
@@ -25,7 +29,7 @@ python << END
 import sys
 import psycopg2
 try:
-    conn = psycopg2.connect(dbname="$POSTGRES_USER", user="$POSTGRES_USER", password="$POSTGRES_PASSWORD", host="postgres")
+    conn = psycopg2.connect(dbname="$POSTGRES_USER", user="$POSTGRES_USER", password="$POSTGRES_PASSWORD", host="$POSTGRES_HOST")
 except psycopg2.OperationalError:
     sys.exit(-1)
 sys.exit(0)

--- a/config/urls.py
+++ b/config/urls.py
@@ -7,6 +7,7 @@ from django.conf.urls.static import static
 from django.contrib import admin
 from django.views import defaults
 from django.views import static as static_views
+from django.http import JsonResponse
 
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
@@ -58,9 +59,14 @@ schema_view = get_schema_view(
     permission_classes=(permissions.AllowAny,),
 )
 
+def health_check(request):
+    return JsonResponse({'status': 'ok'})
+
 urlpatterns += [
     # Django Admin
     path('admin/', admin.site.urls),
+
+    path('health', health_check),
 
     # api docs
     re_path(

--- a/osmchadjango/changeset/tasks.py
+++ b/osmchadjango/changeset/tasks.py
@@ -46,7 +46,7 @@ def create_changeset(changeset_id):
 
 
 def get_filter_changeset_file(url, geojson_filter=settings.CHANGESETS_FILTER):
-    """Filter the changesets of the replication file by the area defined in the
+    """Filter changesets from a replication file by the area defined in the
     GeoJSON file.
     """
     cl = ChangesetList(url, geojson_filter)
@@ -56,13 +56,13 @@ def get_filter_changeset_file(url, geojson_filter=settings.CHANGESETS_FILTER):
 
 
 def format_url(n):
-    """Return the url of a replication file."""
+    """Return the URL of a replication file."""
     n = str(n)
     return join(settings.OSM_PLANET_BASE_URL, '00%s' % n[0], n[1:4], '%s.osm.gz' % n[4:])
 
 
 def import_replications(start, end):
-    """Recieves a start and a end number and import each replication file in
+    """Recieves a start and an end number, and import each replication file in
     this interval.
     """
     Import(start=start, end=end).save()
@@ -73,7 +73,7 @@ def import_replications(start, end):
 
 
 def get_last_replication_id():
-    """Get the id number of the last replication file available on Planet OSM.
+    """Get the id of the last replication file available on Planet OSM.
     """
     state = requests.get(
         '{}state.yaml'.format(settings.OSM_PLANET_BASE_URL)


### PR DESCRIPTION
- Read postgres host from env var
- Get rid of celery decorator for fetch changesets tasks
- Add a lightweight healthcheck endpoint

@willemarcel for the celery tasks, we should consider moving around the definitions a bit to accommodate running them as both celery tasks and plain management commands