### PR TITLE
Un-paginate the user watchlist endpoint

### DIFF
--- a/osmchadjango/supervise/serializers.py
+++ b/osmchadjango/supervise/serializers.py
@@ -3,8 +3,7 @@ from django.urls import reverse
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from rest_framework_gis.fields import GeometryField
 from rest_framework.fields import (
-    SerializerMethodField, HiddenField, CurrentUserDefault, DateTimeField,
-    ReadOnlyField
+    SerializerMethodField, HiddenField, CurrentUserDefault, DateTimeField
     )
 from rest_framework.validators import ValidationError, UniqueTogetherValidator
 from rest_framework.serializers import ModelSerializer
@@ -57,11 +56,10 @@ class AreaOfInterestAnonymousSerializer(AreaOfInterestSerializer):
 
 class BlacklistSerializer(ModelSerializer):
     date = DateTimeField(read_only=True)
-    added_by = ReadOnlyField(source='added_by.username')
 
     class Meta:
         model = BlacklistedUser
-        fields = ('uid', 'username', 'date', 'added_by')
+        fields = ('uid', 'username', 'date')
 
     def validate_uid(self, value):
         # make sure this uid isn't already on the current user's watchlist.

--- a/osmchadjango/supervise/tests/test_views.py
+++ b/osmchadjango/supervise/tests/test_views.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import xml.etree.ElementTree as ET
+from datetime import datetime, timezone
 
 from django.urls import reverse
 from django.conf import settings
@@ -1138,13 +1139,14 @@ class TestBlacklistedUserListAPIView(APITestCase):
         self.client.force_authenticate(user=self.user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data.get('results')), 1)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(set(response.data[0].keys()), {'uid', 'username', 'date'})
 
     def test_list_view_staff_user(self):
         self.client.force_authenticate(user=self.staff_user)
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data.get('results')), 2)
+        self.assertEqual(len(response.data), 2)
 
 
 class TestBlacklistedUserCreateAPIView(APITestCase):
@@ -1243,6 +1245,14 @@ class TestBlacklistedUserDetailAPIViews(APITestCase):
             uid='3434',
             added_by=self.user,
             )
+        BlacklistedUser.objects.filter(pk=self.blacklisted.pk).update(
+            date=datetime(2020, 1, 1, tzinfo=timezone.utc)
+            )
+        BlacklistedUser.objects.filter(pk=self.blacklisted_2.pk).update(
+            date=datetime(2021, 6, 15, tzinfo=timezone.utc)
+            )
+        self.blacklisted.refresh_from_db()
+        self.blacklisted_2.refresh_from_db()
         self.url = reverse(
             'supervise:blacklist-detail', args=[self.blacklisted.uid]
             )
@@ -1256,9 +1266,8 @@ class TestBlacklistedUserDetailAPIViews(APITestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data.get('username'), 'Bad User')
-        self.assertEqual(response.data.get('added_by'), 'test_user')
         self.assertIsNotNone(response.data.get('uid'))
-        self.assertIn('date', response.data.keys())
+        self.assertTrue(response.data.get('date').startswith('2021'))
 
     def test_normal_user_getting_staff_user_blacklist(self):
         blacklisted = BlacklistedUser.objects.create(
@@ -1277,9 +1286,8 @@ class TestBlacklistedUserDetailAPIViews(APITestCase):
         response = self.client.get(self.url)
         self.assertEqual(response.status_code, 200)
         self.assertEqual(response.data.get('username'), 'Bad User')
-        self.assertEqual(response.data.get('added_by'), 'staff_user')
         self.assertIsNotNone(response.data.get('uid'))
-        self.assertIn('date', response.data.keys())
+        self.assertTrue(response.data.get('date').startswith('2020'))
 
     def test_unauthenticated_delete(self):
         response = self.client.delete(self.url)

--- a/osmchadjango/supervise/views.py
+++ b/osmchadjango/supervise/views.py
@@ -234,10 +234,13 @@ class BlacklistedUserListCreateAPIView(ListCreateAPIView):
     queryset = BlacklistedUser.objects.all()
     serializer_class = BlacklistSerializer
     permission_classes = (IsAuthenticated,)
+    pagination_class = None
 
     def get_queryset(self):
         if self.request:
-            return BlacklistedUser.objects.filter(added_by=self.request.user)
+            return BlacklistedUser.objects.filter(
+                added_by=self.request.user
+                ).order_by('-date')
         else:
             BlacklistedUser.objects.none()
 


### PR DESCRIPTION
This is technically a breaking change: the endpoint now returns a JSON array, rather than a DRF pagination object with `{ count, next, previous, results }` keys. Since this API endpoint is only used by the osmcha.org frontend though, I will be releasing it in a minor release and under the existing `/api/v1` URL prefix, consistent with how similar changes have been handled in the past.